### PR TITLE
Enforce security by using Cloud Run identity (#7)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 
 ENV GCLOUD_PROJECT_ID "conference-hall"
 ENV GCLOUD_BUCKET_NAME "firestore-backup-conference-hall-test"
-ENV GCLOUD_SERVICE_KEY "base 64{ type: service_account, project_id: XXX }"
 ENV PORT "8080"
 
 RUN gcloud components install beta

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Please fill in the following information:
 
 Please give a feedback on this **new** way to deploy it ✨
 
+*For this deployment, the new service account can't be used. Simply grant the default (<project_id>-compute@developer.gserviceaccount.com) service account with the required roles*
+
 [![Run on Google Cloud](https://storage.googleapis.com/cloudrun/button.svg)](https://console.cloud.google.com/cloudshell/editor?shellonly=true&cloudshell_image=gcr.io/cloudrun/button&cloudshell_git_repo=https://github.com/Zenika/alpine-firestore-backup)
 
 ## 2. Use a public image

--- a/README.md
+++ b/README.md
@@ -28,12 +28,8 @@ Create a [GCP coldline bucket](https://cloud.google.com/storage/docs/storage-cla
 
 Create a [GCP Service account](https://cloud.google.com/iam/docs/creating-managing-service-accounts) with the following rights:
 
-- `Owner`
-- `Cloud Datastore Owner`
 - `Cloud Datastore Import Export Admin`
 - `Storage Admin`
-
-Then, download the [JSON private key file](https://cloud.google.com/iam/docs/creating-managing-service-account-keys).
 
 ## Prepare your env variables for Cloud Run
 
@@ -41,13 +37,6 @@ Please fill in the following information:
 
 - `GCLOUD_PROJECT_ID`
 - `GCLOUD_BUCKET_NAME`
-- `GCLOUD_SERVICE_KEY`
-
-For the `GCLOUD_SERVICE_KEY`, make a base64 encoded string using this command:
-
-```sh
-cat key.json | base64
-```
 
 # 3 ways to create your image ready to use on Cloud Run
 
@@ -110,7 +99,8 @@ gcloud beta run deploy alpine-firestore-backup\
     --image=zenika-hub/alpine-firestore-backup\
     --memory=256Mi\
     --allow-unauthenticated\
-    --set-env-vars GCLOUD_PROJECT_ID=VALUE,GCLOUD_BUCKET_NAME=VALUE,GCLOUD_SERVICE_KEY=VALUE
+    --set-env-vars GCLOUD_PROJECT_ID=VALUE,GCLOUD_BUCKET_NAME=VALUE\
+    --service-account=my-service-account@my-awesome-project.iam.gserviceaccount.com
 ```
 
 Check the deployment using the following command:
@@ -133,6 +123,7 @@ Be careful to:
 - Enter a service name
 - Select "Allow unauthenticated invocations"
 - In the "Show optional settings / Environment variables", set the 3 environment variables seen in the previous section
+- In the "Service account" part, select your previously created service account
 
 ![cloud-run](https://user-images.githubusercontent.com/525974/62141405-ce9e0800-b2ec-11e9-8763-45efddb4c55d.png)
 

--- a/app.json
+++ b/app.json
@@ -10,11 +10,6 @@
       "description": "please specify the bucket name to store the backups (see https://dev.to/jlandure/how-to-backup-your-firestore-data-automatically-48em for more information)",
       "value": "firestore-backup",
       "required": true
-    },
-    "GCLOUD_SERVICE_KEY": {
-      "description": "please specify the service key allowed to do the operation (see https://dev.to/jlandure/how-to-backup-your-firestore-data-automatically-48em for more information)",
-      "value": "using 'cat key.json | base64'",
-      "required": true
     }
   }
 }

--- a/firestore-export.sh
+++ b/firestore-export.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
-echo "$GCLOUD_SERVICE_KEY" | base64 -d > 'key.json'
-gcloud auth activate-service-account --project="$GCLOUD_PROJECT_ID" --key-file='key.json'
+gcloud config set project $GCLOUD_PROJECT_ID
 gcloud beta firestore export --async gs://"$GCLOUD_BUCKET_NAME"

--- a/operations-list.sh
+++ b/operations-list.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
-echo "$GCLOUD_SERVICE_KEY" | base64 -d > 'key.json'
-gcloud auth activate-service-account --project="$GCLOUD_PROJECT_ID" --key-file='key.json'
+gcloud config set project $GCLOUD_PROJECT_ID
 gcloud beta firestore operations list


### PR DESCRIPTION
Use Cloud Run identity instead of provided service account key file in clear plain text.

Cloud Run Button feature works only if default service account is used and if it has been updated with the required roles.

Images have to be rebuilt and redeployed on zenika GCR